### PR TITLE
unhandled errors not being logged properly

### DIFF
--- a/lib/garb/request/data.rb
+++ b/lib/garb/request/data.rb
@@ -32,7 +32,7 @@ module Garb
         Garb.log "Garb::Response -> #{response.inspect}"
         
         unless response.kind_of?(Net::HTTPSuccess) || (response.respond_to?(:status) && response.status == 200)
-          body, parsed = response.body, MultiJson.load(body) rescue nil
+          body, parsed = response.body, MultiJson.load(response.body) rescue nil
           if parsed and error = parsed['error']
             klass = case error['code']
               when 400 then BadRequestError


### PR DESCRIPTION
I'm on 1.9.3. I'm not sure if this bug was due to that.
