### PR TITLE
A small clarification in the Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Single User Login
 OAuth Access Token
 ------------------
 
-    > Garb::Session.access_token = access_token # assign from oauth gem
+    > Garb::Session.access_token = access_token # an instance of OAuth2::Client
 
 Accounts, WebProperties, Profiles, and Goals
 --------------------------------------------


### PR DESCRIPTION
I simply specified an instance of `OAuth2::Client` is required for using the OAuth2 authentification method.
