### PR TITLE
remove old large blocks of comments

### DIFF
--- a/lib/garb/filter_parameters.rb
+++ b/lib/garb/filter_parameters.rb
@@ -1,18 +1,5 @@
 module Garb
   class FilterParameters
-    # def self.define_operators(*methods)
-    #   methods.each do |method|
-    #     class_eval <<-CODE
-    #       def #{method}(field, value)
-    #         @filter_hash.merge!({SymbolOperator.new(field, :#{method}) => value})
-    #       end
-    #     CODE
-    #   end
-    # end
-
-    # define_operators :eql, :not_eql, :gt, :gte, :lt, :lte, :matches,
-    #   :does_not_match, :contains, :does_not_contain, :substring, :not_substring
-
     attr_accessor :parameters
 
     def initialize(parameters)

--- a/test/unit/garb/filter_parameters_test.rb
+++ b/test/unit/garb/filter_parameters_test.rb
@@ -2,23 +2,6 @@ require 'test_helper'
 
 module Garb
   class FilterParametersTest < MiniTest::Unit::TestCase
-    # def self.should_define_operators(*operators)
-    #   operators.each do |operator|
-    #     should "create an operator and add to parameters for the #{operator} method" do
-    #       new_operator = stub
-    #       symbol = :foo
-    #
-    #       SymbolOperator.expects(:new).with(:bar, operator).returns(new_operator)
-    #       @filter_parameters.filters do
-    #         send(operator.to_sym, :bar, 100)
-    #       end
-    #
-    #       parameter = {new_operator => 100}
-    #       assert_equal parameter, @filter_parameters.parameters.last
-    #     end
-    #   end
-    # end
-
     context "A FilterParameters" do
       context "when converting parameters hash into query string parameters" do
         should "parameterize hash operators and join elements with AND" do


### PR DESCRIPTION
This looks like remnants from earlier design, probably not intended to be committed but certainly not intended to hang around from 2011 until now.

In any event if someone needs it they can dig through the old commits so it makes sense to keep the live code clean.
