### PR TITLE
Garb bad request error "Invalid value 'ga:'. Values must match the following regular expression: '(-)?ga:.+'"

### DIFF
--- a/lib/garb/model.rb
+++ b/lib/garb/model.rb
@@ -83,7 +83,26 @@ module Garb
 
     def parse_sort(options)
       sort = ReportParameter.new(:sort)
-      sort << options[:sort] if options.has_key?(:sort)
+
+      if options.has_key?(:sort)
+        duplicated_operators = {
+          -1 => :desc,
+          '$gt' => :gt,
+          '$gte' => :gte,
+          '$lt' => :lt,
+          '$lte' => :lte
+        }
+        if Object.const_defined?('Origin') &&
+           options[:sort].is_a?(::Origin::Key) &&
+           duplicated_operators.include?(options[:sort].operator)
+          field = options[:sort].name.to_sym
+          operator = duplicated_operators[options[:sort].operator]
+          sort << SymbolOperator.new(field, operator)
+        else
+          sort << options[:sort]
+        end
+      end
+
       sort
     end
 


### PR DESCRIPTION
vigetlabs/garb#54

Using mongoid:

``` console
linyows [master] ✝  bundle exec rails c
[1] 1.9.3(main)> Garb::Session.login(username, password)
[2] 1.9.3(main)> profile = Garb::Management::Profile.all.detect {|p| p.web_property_id == 'UA-XXXXXXX-X'}
[3] 1.9.3(main)> profile.exits(sort: :pageviews.desc)
Garb::BadRequestError: Invalid value 'ga:'. Values must match the following regular expression: '(-)?ga:.+'
from /var/www/app_name/vendor/bundle/ruby/1.9.1/bundler/gems/garb-72ce3c61ea8d/lib/garb/request/data.rb:59:in `handle_response'
```

The symbol-extension is conflicted.

``` console
linyows [master] ✝  bundle exec pry
[1] 1.9.3(main)> :pageviews.desc
NoMethodError: undefined method `desc' for :pageviews:Symbol
from (pry):1:in `__pry__'
[2] 1.9.3(main)> require '/var/www/app_name/vendor/bundle/ruby/1.9.1/gems/origin-1.0.6/lib/origin'
=> true
[3] 1.9.3(main)> :pageviews.desc
=> #<Origin::Key:0x000000026f0a98
 @block=nil,
 @expanded=nil,
 @name=:pageviews,
 @operator=-1,
 @strategy=:__override__>
[4] 1.9.3(main)> require '/var/www/app_name/vendor/bundle/ruby/1.9.1/bundler/gems/garb-72ce3c61ea8d/lib/garb'
=> true
[5] 1.9.3(main)> :pageviews.desc
=> #<Origin::Key:0x000000027496c0
 @block=nil,
 @expanded=nil,
 @name=:pageviews,
 @operator=-1,
 @strategy=:__override__>
[6] 1.9.3(main)> exit
bye
linyows [master] ✝  bundle exec pry
[1] 1.9.3(main)> require '/var/www/app_name/vendor/bundle/ruby/1.9.1/bundler/gems/garb-72ce3c61ea8d/lib/garb'
=> true
[2] 1.9.3(main)> :pageviews.desc
=> #<SymbolOperator:0x00000001ebb6c0 @field=:pageviews, @operator=:desc>
[3] 1.9.3(main)> require '/var/www/app_name/vendor/bundle/ruby/1.9.1/gems/origin-1.0.6/lib/origin'
=> true
[4] 1.9.3(main)> :pageviews.desc
=> #<Origin::Key:0x00000001ec4b58
 @block=nil,
 @expanded=nil,
 @name=:pageviews,
 @operator=-1,
 @strategy=:__override__>
```
