### PR TITLE
Allow alphanumeric segment ids

### DIFF
--- a/lib/garb/model.rb
+++ b/lib/garb/model.rb
@@ -79,7 +79,7 @@ module Garb
     def parse_segment(options)
       # dirty hack to support dynamic segments
       if options.has_key?(:segment_id)
-        segment = "gaid::#{options[:segment_id].to_i}"
+        segment = "gaid::#{options[:segment_id]}"
       elsif options.has_key?(:dynamic_segment)
         filters = FilterParameters.new(options[:dynamic_segment])
         segment = "dynamic::#{filters.to_params['filters']}"

--- a/test/unit/garb/model_test.rb
+++ b/test/unit/garb/model_test.rb
@@ -98,6 +98,11 @@ module Garb
             assert_data_params(@params.merge({'segment' => 'gaid::1'}))
           end
 
+          should "be able to set the filter segment by alphanumeric id" do
+            assert_equal @results, @test_model.results(@profile, :segment_id => '1a')
+            assert_data_params(@params.merge({'segment' => 'gaid::1a'}))
+          end
+
           should "be able to filter with a dynamic segment" do
             # parse_filters called first...
             filter_parameters = stub(:<<)


### PR DESCRIPTION
GA has introduced new alphanumeric ids for Advanced Segments (See changelog entry 'Release 2013-07-15 (July 16, 2013)' [here](https://developers.google.com/analytics/devguides/reporting/core/v3/changelog%29)), so Garb can't call `to_i` on them any more without causing problems.
