### PR TITLE
warning: mismatched indentations at 'end' with 'module' at 11

### DIFF
--- a/lib/garb.rb
+++ b/lib/garb.rb
@@ -36,7 +36,7 @@ module Garb
     autoload :Authentication, 'garb/request/authentication'
     autoload :Data,           'garb/request/data'
   end
- end
+end
 
 module Garb
   extend self


### PR DESCRIPTION
This patch fixes a trivial ruby-level warning.
