### PR TITLE
Define equality of SymbolOperator instances

### DIFF
--- a/lib/garb/core_ext/symbol.rb
+++ b/lib/garb/core_ext/symbol.rb
@@ -7,13 +7,13 @@ module SymbolOperatorMethods
     :lt      => '<',
     :lte     => '<=',
     :matches => '==',
-    
+
     :does_not_match   => '!=',
     :contains         => '=~',
     :does_not_contain => '!~',
     :substring        => '=@',
     :not_substring    => '!@',
-    
+
     :desc       => '-',
     :descending => '-'
   }
@@ -29,10 +29,21 @@ end
 
 class SymbolOperator
   include SymbolOperatorMethods
-  
+
+  attr_reader :field, :operator
+
   def initialize(field, operator)
     @field, @operator = field, operator
   end unless method_defined? :initialize
+
+  def ==(other)
+    field == other.field && operator == other.operator
+  end
+  alias eql? ==
+
+  def hash
+    [field, operator].hash
+  end
 end
 
 symbol_slugs = if Object.const_defined?('DataMapper')

--- a/test/unit/symbol_operator_test.rb
+++ b/test/unit/symbol_operator_test.rb
@@ -14,24 +14,26 @@ class SymbolOperatorTest < MiniTest::Unit::TestCase
       assert_equal "-ga:metric", SymbolOperator.new(:metric, :desc).to_google_analytics
     end
 
-    # should "know if it is equal to another operator" do
-    #   op1 = SymbolOperator.new(:hello, "==")
-    #   op2 = SymbolOperator.new(:hello, "==")
-    #   assert_equal op1, op2
-    # end
-    #
-    # should "not be equal to another operator if target, operator, or prefix is different" do
-    #   op1 = SymbolOperator.new(:hello, "==")
-    #   op2 = SymbolOperator.new(:hello, "==", true)
-    #   refute_equal op1, op2
-    #
-    #   op1 = SymbolOperator.new(:hello1, "==")
-    #   op2 = SymbolOperator.new(:hello2, "==")
-    #   refute_equal op1, op2
-    #
-    #   op1 = SymbolOperator.new(:hello, "!=")
-    #   op2 = SymbolOperator.new(:hello, "==")
-    #   refute_equal op1, op2
-    # end
+    should 'know if it is equal to another instance' do
+      op1 = SymbolOperator.new(:hello, '==')
+      op2 = SymbolOperator.new(:hello, '==')
+      assert_equal op1, op2
+      assert op1.eql?(op2)
+      assert_equal op1.hash, op2.hash
+    end
+
+    should 'not be equal to another instance if different target or operator' do
+      op1 = SymbolOperator.new(:hello1, '==')
+      op2 = SymbolOperator.new(:hello2, '==')
+      refute_equal op1, op2
+      refute op1.eql?(op2)
+      refute_equal op1.hash, op2.hash
+
+      op1 = SymbolOperator.new(:hello, '!=')
+      op2 = SymbolOperator.new(:hello, '==')
+      refute_equal op1, op2
+      refute op1.eql?(op2)
+      refute_equal op1.hash, op2.hash
+    end
   end
 end


### PR DESCRIPTION
Defined #eql? and #hash as well since they are used for hash key lookup, so that the following is truthy:

```ruby
{ :hostname.eql => 'example.com }.key?(:hostname.eql)
```

While writing a test asserting the filters passed in my own app, it wouldn't pass because the SymbolOperator instances were not equal even though their values were identical and the hash was different for each instance, so checking the filters hash for the existence of a key would fail.