### PR TITLE
Avoid NoMethodError when comparing ResultSet to other objects

### DIFF
--- a/lib/garb/result_set.rb
+++ b/lib/garb/result_set.rb
@@ -16,6 +16,7 @@ module Garb
     end
 
     def <=>(other)
+      return nil unless other.is_a?(Garb::ResultSet)
       results <=> other.results
     end
 


### PR DESCRIPTION
Without this, `Garb::ResultSet.new([]) == true` raises NoMethodError, which seems undesirable.